### PR TITLE
[FEATURE#27818] Amelioration du provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,16 @@ class IndexNameElasticsearchIndexer extends AbstractETNAIndexer
         parent::__construct($app, "index_name");
     }
 
+    protected function indexOneMyFirstType($id)
+    {
+      //Code here
+    }
+
+    protected function indexOneMySecondType($id)
+    {
+      //Code here
+    }
+
     protected function indexMyFirstType()
     {
       //Code here

--- a/README.md
+++ b/README.md
@@ -30,17 +30,25 @@ Modifier `composer.json` :
 
 Dans le fichier d'env :
 
+ - Une variable <INDEX_NAME>_ELASTICSEARCH_HOST qui contient l'adresse et le nom de l'index ES
+ - Une variable <INDEX_NAME>_ELASTICSEARCH_TYPES qui contient la liste des types de l'index séparés par une `,`
+
 ```
 putenv("INDEX_NAME_ELASTICSEARCH_HOST=http://elasticsearch.etna-alternance.eu:9200/index_name");
-putenv("INDEX_NAME_ELASTICSEARCH_TYPE=my_type");
+putenv("INDEX_NAME_ELASTICSEARCH_TYPES=my_first_type,my_second_type");
 
 putenv("OTHER_INDEX_NAME_ELASTICSEARCH_HOST=http://elasticsearch.etna-alternance.eu:9200/other_index_name");
-putenv("OTHER_INDEX_NAME_ELASTICSEARCH_TYPE=my_other_type");
+putenv("OTHER_INDEX_NAME_ELASTICSEARCH_TYPES=my_other_type");
 ```
 
 ###Register
 
 Pour chaque index différent créer une classe `IndexElasticsearch` qui hérite de `AbstractEtnaIndexer`
+Il faut implémenter une foncion par type de l'index pour indexer son contenu.
+
+Par exemple pour l'index `index_name` il faudra implémenter (comme dans l'exemple suivant) les fonctions :
+ - indexMyFirstType
+ - indexMySecondType
 
 ```
 use ETNA\Silex\Provider\Elasticsearch\AbstractETNAIndexer;
@@ -54,22 +62,39 @@ class IndexNameElasticsearchIndexer extends AbstractETNAIndexer
         parent::__construct($app, "index_name");
     }
 
-    public function reindex()
+    protected function indexMyFirstType()
     {
       //Code here
     }
 
-    public function putDocument(Entity $entity = null)
+    protected function indexMySecondType()
     {
       //Code here
     }
 
-    public function removeDocument(Entity $entity = null)
+    public function putDocument($type, Entity $entity = null)
+    {
+      //Code here
+    }
+
+    public function removeDocument($type, Entity $entity = null)
     {
       //Code here
     }
 }
 ```
+
+Les paramêtres de l'index vont se chercher dans un dossier.
+Pour indiquer à l'application ou est ce dossier :
+```
+$app["elasticsearch_index_name_parameters_path"] = "my/path/to/folder";
+```
+
+Ce dossier doit avoir l'arborescence suivante :
+  - IndexNameParameters :
+    - settings.json : Settings de l'index
+    - my_first_type-mapping.json : Mapping pour le type my_first_type
+    - my_second_type-mapping.json : Mapping pour le type my_second_type
 
 Puis dans le fichier de configuration :
 

--- a/src/AbstractEtnaIndexer.php
+++ b/src/AbstractEtnaIndexer.php
@@ -7,13 +7,15 @@ use Silex\Application;
 abstract class AbstractEtnaIndexer
 {
     protected $app;
+    protected $name;
 
     /**
      * @param Application $app
      */
     public function __construct(Application $app, $name)
     {
-        $this->app = $app;
+        $this->app  = $app;
+        $this->name = $name;
 
         $this->app["elasticsearch.{$name}.reindex"]         = [$this, 'reindex'];
         $this->app["elasticsearch.{$name}.put_document"]    = [$this, 'putDocument'];
@@ -23,15 +25,32 @@ abstract class AbstractEtnaIndexer
     /**
      * @return void
      */
-    abstract public function reindex();
+    public function reindex($types = [])
+    {
+        if (!empty($invalid_types = array_diff($types, $this->app["elasticsearch.{$this->name}.types"]))) {
+            throw new \Exception("Invalid type(s) " . implode(', ', $types) . " for index {$this->name}");
+        }
+
+        if (empty($types)) {
+            $types = $this->app["elasticsearch.{$this->name}.types"];
+        }
+
+        foreach ($types as $type) {
+            $index_func_name = "index" . implode('', array_map('ucfirst', explode('_', $type)));
+            if (!method_exists($this, $index_func_name)) {
+                throw new \Exception("Implement the method {$index_func_name} as protected to index type {$type}");
+            }
+            $this->{$index_func_name}();
+        }
+    }
 
     /**
      * @return array
      */
-    abstract public function putDocument();
+    abstract public function putDocument($type);
 
     /**
      * @return void
      */
-    abstract public function removeDocument();
+    abstract public function removeDocument($type);
 }

--- a/src/AbstractEtnaIndexer.php
+++ b/src/AbstractEtnaIndexer.php
@@ -18,8 +18,21 @@ abstract class AbstractEtnaIndexer
         $this->name = $name;
 
         $this->app["elasticsearch.{$name}.reindex"]         = [$this, 'reindex'];
+        $this->app["elasticsearch.{$name}.index_one"]       = [$this, 'indexOne'];
         $this->app["elasticsearch.{$name}.put_document"]    = [$this, 'putDocument'];
         $this->app["elasticsearch.{$name}.remove_document"] = [$this, 'removeDocument'];
+    }
+
+    public function indexOne($type, $id)
+    {
+        if (false === in_array($type, $this->app["elasticsearch.{$this->name}.types"])) {
+            throw new \Exception("Invalid type {$type} for index {$this->name}");
+        }
+        $index_one_func_name = "indexOne" . implode('', array_map('ucfirst', explode('_', $type)));
+        if (!method_exists($this, $index_one_func_name)) {
+            throw new \Exception("Implement the method {$index_one_func_name} as protected to index one type {$type}");
+        }
+        $this->{$index_one_func_name}($id);
     }
 
     /**

--- a/src/Elasticsearch.php
+++ b/src/Elasticsearch.php
@@ -148,11 +148,11 @@ class Elasticsearch implements ServiceProviderInterface
         }
 
         if (!in_array($type, $app["elasticsearch.{$name}.types"])) {
-            throw new \Exception("Application is not configured for type {$name}/{$type}");
+            throw new \Exception("Application is not configured for type {$app["elasticsearch.$name.index"]}/{$type}");
         }
 
         if (true === $reset) {
-            echo "\nCreating elasticsearch type {$type} for index {$name}\n";
+            echo "\nCreating elasticsearch type {$type} for index {$app["elasticsearch.$name.index"]}\n";
 
             $parameters_path = $app["elasticsearch_{$name}_parameters_path"];
             if (!file_exists("{$parameters_path}/{$type}-mapping.json")) {
@@ -168,7 +168,7 @@ class Elasticsearch implements ServiceProviderInterface
                     "type"  => $type
                 ]);
             } catch (\Exception $exception) {
-                echo "Type {$name}/{$type} doesn't exist... \n";
+                echo "Type {$app["elasticsearch.$name.index"]}/{$type} doesn't exist... \n";
             }
 
             $app["elasticsearch.{$name}"]->indices()->putMapping([
@@ -177,7 +177,7 @@ class Elasticsearch implements ServiceProviderInterface
                 "body"  => $mapping
             ]);
 
-            echo "Type {$name}/{$type} created successfully!\n\n";
+            echo "Type {$app["elasticsearch.$name.index"]}/{$type} created successfully!\n\n";
         }
     }
 

--- a/src/Elasticsearch.php
+++ b/src/Elasticsearch.php
@@ -27,19 +27,19 @@ class Elasticsearch implements ServiceProviderInterface
 
         $this->es_options = [];
         foreach ($es_options as $db_name) {
-            $name              = strtoupper($db_name);
-            $elasicsearch_host = getenv("{$name}_ELASTICSEARCH_HOST");
-            $elasicsearch_type = getenv("{$name}_ELASTICSEARCH_TYPE");
+            $name                = strtoupper($db_name);
+            $elasicsearch_host   = getenv("{$name}_ELASTICSEARCH_HOST");
+            $elasticsearch_types = getenv("{$name}_ELASTICSEARCH_TYPES");
             if (false === $elasicsearch_host) {
                 throw new \Exception("{$name}_ELASTICSEARCH_HOST doesn't exist");
             }
-            if (false === $elasicsearch_type) {
-                throw new \Exception("{$name}_ELASTICSEARCH_TYPE doesn't exist");
+            if (false === $elasticsearch_types) {
+                throw new \Exception("{$name}_ELASTICSEARCH_TYPES doesn't exist");
 
             }
             $this->es_options[$db_name] = [
-                "host"    => $elasicsearch_host,
-                "type"    => $elasicsearch_type
+                "host"  => $elasicsearch_host,
+                "types" => explode(',', $elasticsearch_types)
             ];
         }
     }
@@ -69,7 +69,7 @@ class Elasticsearch implements ServiceProviderInterface
 
             $app["elasticsearch.{$name}.server"] = str_replace($parsed_url['path'], '', $es_option['host']) . "/";
             $app["elasticsearch.{$name}.index"]  = $index;
-            $app["elasticsearch.{$name}.type"]   = $es_option['type'];
+            $app["elasticsearch.{$name}.types"]  = $es_option['types'];
 
             $app["elasticsearch.{$name}"] = ClientBuilder::create()
                 ->setHosts([$app["elasticsearch.{$name}.server"]])
@@ -77,6 +77,7 @@ class Elasticsearch implements ServiceProviderInterface
         }
 
         $app['elasticsearch.create_index'] = [$this, 'createIndex'];
+        $app["elasticsearch.create_type"]  = [$this, 'createType'];
         $app['elasticsearch.lock']         = [$this, 'lock'];
         $app['elasticsearch.unlock']       = [$this, 'unlock'];
     }
@@ -84,6 +85,10 @@ class Elasticsearch implements ServiceProviderInterface
     public function createIndex($name, $reset = false)
     {
         $app = $this->app;
+
+        if (!in_array($name, $app["elasticsearch.names"])) {
+            throw new \Exception("Application is not configured for index {$name}");
+        }
 
         if (!isset($app["version"])) {
             throw new \Exception('$app["version"] is not set');
@@ -102,18 +107,14 @@ class Elasticsearch implements ServiceProviderInterface
                 echo "Index {$app["elasticsearch.$name.index"]}-{$app["version"]} doesn't exist... \n";
             }
 
+            $parameters_path = $app["elasticsearch_{$name}_parameters_path"];
             // On récupère les settings et les mappings pour créer l'index
-            $settings = json_decode(file_get_contents($app["elasticsearch_{$name}_settings_path"]), true);
-            $mappings = json_decode(file_get_contents($app["elasticsearch_{$name}_mappings_path"]), true);
+            $settings = json_decode(file_get_contents("$parameters_path/settings.json"), true);
 
             $index_params = [
                 "index" => "{$app["elasticsearch.$name.index"]}-{$app["version"]}",
-                "body"  => [
-                    "settings" => $settings,
-                    "mappings" => $mappings
-                ]
+                "body"  => ["settings" => $settings]
             ];
-
             // Création de l'index
             $app["elasticsearch.$name"]->indices()->create($index_params);
 
@@ -131,6 +132,52 @@ class Elasticsearch implements ServiceProviderInterface
             $app["elasticsearch.{$name}"]->indices()->putAlias($alias);
 
             echo "Index {$app["elasticsearch.$name.index"]} created successfully!\n\n";
+
+            foreach ($app["elasticsearch.{$name}.types"] as $type) {
+                self::createType($name, $type, $reset);
+            }
+        }
+    }
+
+    public function createType($name, $type, $reset = false)
+    {
+        $app = $this->app;
+
+        if (!in_array($name, $app["elasticsearch.names"])) {
+            throw new \Exception("Application is not configured for index {$name}");
+        }
+
+        if (!in_array($type, $app["elasticsearch.{$name}.types"])) {
+            throw new \Exception("Application is not configured for type {$name}/{$type}");
+        }
+
+        if (true === $reset) {
+            echo "\nCreating elasticsearch type {$type} for index {$name}\n";
+
+            $parameters_path = $app["elasticsearch_{$name}_parameters_path"];
+            if (!file_exists("{$parameters_path}/{$type}-mapping.json")) {
+                throw new \Exception("Mapping file for type {$type} does not exist");
+            }
+            $mapping = json_decode(file_get_contents("{$parameters_path}/{$type}-mapping.json"), true);
+
+            $this->unlock($name);
+
+            try {
+                $app["elasticsearch.{$name}"]->indices()->deleteMapping([
+                    "index" => $name,
+                    "type"  => $type
+                ]);
+            } catch (\Exception $exception) {
+                echo "Type {$name}/{$type} doesn't exist... \n";
+            }
+
+            $app["elasticsearch.{$name}"]->indices()->putMapping([
+                "index" => $name,
+                "type"  => $type,
+                "body"  => $mapping
+            ]);
+
+            echo "Type {$name}/{$type} created successfully!\n\n";
         }
     }
 

--- a/src/Elasticsearch.php
+++ b/src/Elasticsearch.php
@@ -164,7 +164,7 @@ class Elasticsearch implements ServiceProviderInterface
 
             try {
                 $app["elasticsearch.{$name}"]->indices()->deleteMapping([
-                    "index" => $name,
+                    "index" => $app["elasticsearch.{$name}.index"],
                     "type"  => $type
                 ]);
             } catch (\Exception $exception) {
@@ -172,7 +172,7 @@ class Elasticsearch implements ServiceProviderInterface
             }
 
             $app["elasticsearch.{$name}"]->indices()->putMapping([
-                "index" => $name,
+                "index" => $app["elasticsearch.{$name}.index"],
                 "type"  => $type,
                 "body"  => $mapping
             ]);


### PR DESCRIPTION
Maintenant il est possible de gerer plusieurs types par indexes.
- Implementation de la fonction `createType` qui se comporte comme la fonction `createIndex` mais pour les types.
- Changement de l'`AbstractEtnaIndexer` qui implemente directement la fonction `reindex`
