### PR TITLE
[FIX#40258] Changement de l'ordre des actions

### DIFF
--- a/src/Elasticsearch.php
+++ b/src/Elasticsearch.php
@@ -98,6 +98,16 @@ class Elasticsearch implements ServiceProviderInterface
             echo "\nCreating elasticsearch index... {$app["elasticsearch.$name.index"]}\n";
             $this->unlock($name);
 
+            $alias = [
+                "index" => "{$app["elasticsearch.$name.index"]}-{$app["version"]}",
+                "name"  => $app["elasticsearch.{$name}.index"]
+            ];
+            try {
+                $app["elasticsearch.{$name}"]->indices()->deleteAlias($alias);
+            } catch (\Exception $e) {
+                echo "Alias doesn't exist... \n";
+            }
+
             // On supprime l'index
             try {
                 $app["elasticsearch.{$name}"]->indices()->delete(
@@ -119,18 +129,7 @@ class Elasticsearch implements ServiceProviderInterface
             $app["elasticsearch.$name"]->indices()->create($index_params);
 
             // Rajout de l'alias
-            $alias = [
-                "index" => "{$app["elasticsearch.$name.index"]}-{$app["version"]}",
-                "name"  => $app["elasticsearch.{$name}.index"]
-            ];
-
-            try {
-                $app["elasticsearch.{$name}"]->indices()->deleteAlias($alias);
-            } catch (\Exception $e) {
-                echo "Alias doesn't exist... \n";
-            }
             $app["elasticsearch.{$name}"]->indices()->putAlias($alias);
-
             echo "Index {$app["elasticsearch.$name.index"]} created successfully!\n\n";
 
             foreach ($app["elasticsearch.{$name}.types"] as $type) {


### PR DESCRIPTION
Lors qu'on reset l'index on change un peu l'ordre des choses pour regagner en cohérence :

 1. Suppression de l'alias si il existe
 2. Suppression de l'index si il existe
 3. Création de l'index
 4. Création de l'alias sur l'index fraichement crée